### PR TITLE
Fix for failing test

### DIFF
--- a/Gu.Wpf.PropertyGrid.UiTests/TypedRowTests/EnumRowTests.cs
+++ b/Gu.Wpf.PropertyGrid.UiTests/TypedRowTests/EnumRowTests.cs
@@ -27,9 +27,8 @@ namespace Gu.Wpf.PropertyGrid.UiTests
 
                 window.FindComboBoxRow("lostfocus").Value().EditableText = "InvariantCulture";
                 Assert.AreEqual("CurrentCultureIgnoreCase", window.FindTextBlock("currentTextBlock").Text);
-
+                window.FindComboBoxRow("lostfocus").Value().Click();
                 window.FindButton("lose focus").Click();
-                Wait.For(TimeSpan.FromMilliseconds(100));
                 Assert.AreEqual("InvariantCulture", window.FindTextBlock("currentTextBlock").Text);
             }
         }


### PR DESCRIPTION
The combobox requires an extra click to close the combo box drop-down list.